### PR TITLE
Update README.md to add Requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # Swoopy
-A Python script to swoop and decrypt passwords from Chrome's local storage.
+A Python 2.X script to swoop and decrypt passwords from Chrome's local storage.
+
+# Requirements & Expectations
+Swoopy was written for Python 2.X, not for Python 3.X.
+
+Swoopy expects that the Chrome passwords to decrypt are stored in the file "%HOMEPATH%\AppData\Local\Google\Chrome\User Data\Default\Login Data", which is the default location that Chrome stores them. Chromium stores them elsewhere.
+
+Swoopy must be run on the same computer that "Login Data" was created/encrypted on.


### PR DESCRIPTION
Explicitly states that this is for _Python 2.X_, and not for _Python 3.X_ .

The Chrome password location requirement mentions "_%HOMEPATH%_". This is a Windows environment variable that translates to "_\Users\\{username}_" according to the following source:
https://ss64.com/nt/syntax-variables.html#tbl

The requirement that Swoopy be run on the same computer that the "_Login Data_" file was created on was discussed in issue #4 .